### PR TITLE
[Locations check] Can accept Arrays and Ranges

### DIFF
--- a/games/FNaFB1/Ruby/gems/archipelago_rb/archipelago_rb/locations.rb
+++ b/games/FNaFB1/Ruby/gems/archipelago_rb/archipelago_rb/locations.rb
@@ -27,6 +27,8 @@ module Archipelago
                 if @client.client_connect_status == ConnectStatus::CONNECTED
                     id_arguments.each do |id|
                         @checked_locations << id if id.is_a?(Integer)
+                        @checked_locations.concat(id) if id.is_a?(Array)
+                        @checked_locations.concat(id.to_a) if id.is_a?(Range)
                     end
 
                     check_packet = Packets::LocationChecks.new(@checked_locations)


### PR DESCRIPTION
Changes:
+ LocationsManager "check" method can now accept Array and Range inputs.
Example: `$archipelago.locations.check(1, 2, 3..6, [7, 8, 9])`
`# Checks locations with ID [1, 2, 3, 4, 5, 6, 7, 8, 9]`